### PR TITLE
Implementation of the BF extraction R2 not dependent

### DIFF
--- a/Base/HistogramCollection.cpp
+++ b/Base/HistogramCollection.cpp
@@ -1239,6 +1239,45 @@ void HistogramCollection::calculateG2_H2H2H2H2(const TH2 * spp, const TH2 * n1n1
 
 }
 
+/* calculate the balance functions components associated to the current pair */
+/* independent of R2, two components are alway computed, for LS they will match but don't for US */
+void HistogramCollection::calculateBf(const TH2 *n2, const TH2 *n1_1, const TH2 *n1_2, TH2 *bf_12, TH2 *bf_21)
+{
+  int nbinsx = n2->GetNbinsX();
+  int nbinsy = n2->GetNbinsY();
+
+  bf_12->Reset();
+  bf_21->Reset();
+  double n11_inte = 0.0;
+  double n11_int = n1_1->IntegralAndError(1,n1_1->GetNbinsX(),1,n1_1->GetNbinsY(),n11_inte);
+  double n11_inter = n11_inte/n11_int;
+
+  double n12_inte = 0.0;
+  double n12_int = n1_2->IntegralAndError(1,n1_2->GetNbinsX(),1,n1_2->GetNbinsY(),n12_inte);
+  double n12_inter = n12_inte/n12_int;
+
+  for (int ix = 0; ix < nbinsx; ++ix)
+  {
+    for (int iy = 0; iy < nbinsy; ++iy)
+    {
+      double v = n2->GetBinContent(ix+1,iy+1);
+      double ve = n2->GetBinError(ix+1,iy+1);
+
+      double v12 = v/n12_int;
+      double v12e = v12*TMath::Sqrt(ve/v*ve/v+n12_inter*n12_inter);
+      double v21 = v/n11_int;
+      double v21e = v21*TMath::Sqrt(ve/v*ve/v+n11_inter*n11_inter);
+
+      bf_12->SetBinContent(ix+1,iy+1,v12);
+      bf_12->SetBinError(ix+1,iy+1,v12e);
+      bf_21->SetBinContent(iy+1,ix+1,v21);
+      bf_21->SetBinError(iy+1,ix+1,v21e);
+    }
+  }
+  bf_12->SetEntries(n2->GetEntries());
+  bf_21->SetEntries(n2->GetEntries());
+}
+
 void HistogramCollection::calculateSean_H1H2H2H2(const TH1 * spp, const TH2 * n1n1, const TH2 * pt1pt1, TH2 * sean, bool ijNormalization, double a1, double a2)
 {
 

--- a/Base/HistogramCollection.hpp
+++ b/Base/HistogramCollection.hpp
@@ -225,6 +225,7 @@ public:
                        bool ijNormalization, int nBins);
   void calculateSc(const TH1 * spp, const TH1 * n1n1, const TH1 * pt1pt1, TH1 * sean, bool ijNormalization);
   void calculateG2_H2H2H2H2(const TH2 * spp, const TH2 * n1n1, const TH2 * pt1pt1, TH2 * sean, bool ijNormalization, double a1, double a2);
+  void calculateBf(const TH2 *n2, const TH2 *n1_1, const TH2 *n1_2, TH2 *bf_12, TH2 *bf_21);
   void calculateSean_H1H2H2H2(const TH1 * spp, const TH2 * n1n1, const TH2 * pt1pt1, TH2 * sean, bool ijNormalization, double a1, double a2);
   int  calculateQ3DwPtPhiEta(double pt1, double phi1, double eta1,
                              double pt2, double phi2, double eta2,

--- a/Base/ParticlePairCombinedHistos.cpp
+++ b/Base/ParticlePairCombinedHistos.cpp
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Claude Pruneau. All rights reserved.
 //
 #include "ParticlePairCombinedHistos.hpp"
-ClassImp(ParticlePairCombinedHistos);
+ClassImp(ParticlePairCombinedHistos)
 
 
 ParticlePairCombinedHistos::ParticlePairCombinedHistos(const TString & name,
@@ -118,6 +118,9 @@ ParticlePairCombinedHistos::~ParticlePairCombinedHistos()
     h_G2_phiPhi            = createHistogram(bn+TString("G2_phiPhi"),            ac.nBins_phi,   ac.min_phi,   ac.max_phi,   ac.nBins_phi,   ac.min_phi,       ac.max_phi,       "#varphi_{1}", "#varphi_{2}",   "G_{2}", true,true,true,true);
     h_G2_DetaDphi_shft     = createHistogram(bn+TString("G2_DetaDphi_shft"),     ac.nBins_Deta,  ac.min_Deta,  ac.max_Deta,  ac.nBins_Dphi,  ac.min_Dphi_shft, ac.max_Dphi_shft, "#Delta#eta",  "#Delta#varphi", "G_{2}", true,true,true,true);
 
+    h_BF_etaEta            = createHistogram(bn+TString("BF_etaEta"),            ac.nBins_eta,   ac.min_eta,   ac.max_eta,   ac.nBins_eta,   ac.min_eta,       ac.max_eta,       "#eta_{1}",    "#eta_{2}",      "BF_{2}", true,true,true,true);
+    h_BF_phiPhi            = createHistogram(bn+TString("BF_phiPhi"),            ac.nBins_phi,   ac.min_phi,   ac.max_phi,   ac.nBins_phi,   ac.min_phi,       ac.max_phi,       "#varphi_{1}", "#varphi_{2}",   "BF_{2}", true,true,true,true);
+    h_BF_DetaDphi_shft     = createHistogram(bn+TString("BF_DetaDphi_shft"),     ac.nBins_Deta,  ac.min_Deta,  ac.max_Deta,  ac.nBins_Dphi,  ac.min_Dphi_shft, ac.max_Dphi_shft, "#Delta#eta",  "#Delta#varphi", "BF_{2}", true,true,true,true);
 
 
     if (ac.fillY)
@@ -133,6 +136,9 @@ ParticlePairCombinedHistos::~ParticlePairCombinedHistos()
 
       h_G2_yY              = createHistogram(bn+TString("G2_yY"),                ac.nBins_y,   ac.min_y,   ac.max_y,   ac.nBins_y,     ac.min_y,         ac.max_y,         "y_{1}",      "y_{2}",         "G_{2}", true,true,true,true);
       h_G2_DyDphi_shft     = createHistogram(bn+TString("G2_DyDphi_shft"),       ac.nBins_Dy,  ac.min_Dy,  ac.max_Dy,  ac.nBins_Dphi,  ac.min_Dphi_shft, ac.max_Dphi_shft, "#Delta y",   "#Delta#varphi", "G_{2}", true,true,true,true);
+
+      h_BF_yY              = createHistogram(bn+TString("BF_yY"),                ac.nBins_y,   ac.min_y,   ac.max_y,   ac.nBins_y,     ac.min_y,         ac.max_y,         "y_{1}",      "y_{2}",         "BF_{2}", true,true,true,true);
+      h_BF_DyDphi_shft     = createHistogram(bn+TString("BF_DyDphi_shft"),       ac.nBins_Dy,  ac.min_Dy,  ac.max_Dy,  ac.nBins_Dphi,  ac.min_Dphi_shft, ac.max_Dphi_shft, "#Delta y",   "#Delta#varphi", "BF_{2}", true,true,true,true);
     }
 
   if (ac.fillQ3D)
@@ -196,6 +202,18 @@ ParticlePairCombinedHistos::~ParticlePairCombinedHistos()
     h_G2_DetaDphi_shft->Add(pp->h_G2_DetaDphi_shft, mm->h_G2_DetaDphi_shft, app, amm);
     h_G2_DetaDphi_shft->Add(pm->h_G2_DetaDphi_shft, apm);
 
+    h_BF_DetaDphi_shft->Add(pp->h_bf12_DetaDphi_shft, mm->h_bf12_DetaDphi_shft, app, amm);
+    h_BF_DetaDphi_shft->Add(pm->h_bf12_DetaDphi_shft, apm/2.0);
+    h_BF_DetaDphi_shft->Add(pm->h_bf21_DetaDphi_shft, apm/2.0);
+
+    h_BF_etaEta->Add(pp->h_bf12_etaEta, mm->h_bf12_etaEta, app, amm);
+    h_BF_etaEta->Add(pm->h_bf12_etaEta, apm/2.0);
+    h_BF_etaEta->Add(pm->h_bf21_etaEta, apm/2.0);
+
+    h_BF_phiPhi->Add(pp->h_bf12_phiPhi, mm->h_bf12_phiPhi, app, amm);
+    h_BF_phiPhi->Add(pm->h_bf12_phiPhi, apm/2.0);
+    h_BF_phiPhi->Add(pm->h_bf21_phiPhi, apm/2.0);
+
     if (ac.fillY)
     {
       h_R2_yY->Add(pp->h_R2_yY, mm->h_R2_yY, app, amm);
@@ -218,6 +236,14 @@ ParticlePairCombinedHistos::~ParticlePairCombinedHistos()
 
       h_G2_DyDphi_shft->Add(pp->h_G2_DyDphi_shft, mm->h_G2_DyDphi_shft, app, amm);
       h_G2_DyDphi_shft->Add(pm->h_G2_DyDphi_shft, apm);
+
+      h_BF_yY->Add(pp->h_bf12_yY, mm->h_bf12_yY, app, amm);
+      h_BF_yY->Add(pm->h_bf12_yY, apm/2.0);
+      h_BF_yY->Add(pm->h_bf21_yY, apm/2.0);
+
+      h_BF_DyDphi_shft->Add(pp->h_bf12_DyDphi_shft, mm->h_bf12_DyDphi_shft, app, amm);
+      h_BF_DyDphi_shft->Add(pm->h_bf12_DyDphi_shft, apm/2.0);
+      h_BF_DyDphi_shft->Add(pm->h_bf21_DyDphi_shft, apm/2.0);
     }
 
     if (ac.fillQ3D)

--- a/Base/ParticlePairCombinedHistos.hpp
+++ b/Base/ParticlePairCombinedHistos.hpp
@@ -63,6 +63,12 @@ public:
   TH2* h_G2_yY;
   TH2* h_G2_DyDphi_shft;
 
+  TH2* h_BF_etaEta;
+  TH2* h_BF_phiPhi;
+  TH2* h_BF_DetaDphi_shft;
+  TH2* h_BF_yY;
+  TH2* h_BF_DyDphi_shft;
+
   TH3* h_R2_Q3D;
   TH2* h_R2_Q3D_xy;
   TH2* h_R2_Q3D_xz;
@@ -79,7 +85,7 @@ public:
   TH1 * h_RR2_Q3D_y;
   TH1 * h_RR2_Q3D_z;
   
-    ClassDef(ParticlePairCombinedHistos,0)
+    ClassDef(ParticlePairCombinedHistos,1)
 };
 
 

--- a/Base/ParticlePairDerivedHistos.cpp
+++ b/Base/ParticlePairDerivedHistos.cpp
@@ -88,6 +88,17 @@ ParticlePairDerivedHistos::ParticlePairDerivedHistos(const TString & name,
    h_P2_etaEta            = loadH2(inputFile, bn+TString("P2_etaEta"));
    h_P2_phiPhi            = loadH2(inputFile, bn+TString("P2_phiPhi"));
 
+  h_bf12_phiEtaPhiEta     = loadH2(inputFile, bn+TString("bf12_phiEtaPhiEta"));
+  h_bf12_etaEta           = loadH2(inputFile, bn+TString("bf12_etaEta"));
+  h_bf12_phiPhi           = loadH2(inputFile, bn+TString("bf12_phiPhi"));
+  h_bf12_DetaDphi         = loadH2(inputFile, bn+TString("bf12_DetaDphi"));
+  h_bf12_DetaDphi_shft    = loadH2(inputFile, bn+TString("bf12_DetaDphi_shft"));
+  h_bf21_phiEtaPhiEta     = loadH2(inputFile, bn+TString("bf21_phiEtaPhiEta"));
+  h_bf21_etaEta           = loadH2(inputFile, bn+TString("bf21_etaEta"));
+  h_bf21_phiPhi           = loadH2(inputFile, bn+TString("bf21_phiPhi"));
+  h_bf21_DetaDphi         = loadH2(inputFile, bn+TString("bf21_DetaDphi"));
+  h_bf21_DetaDphi_shft    = loadH2(inputFile, bn+TString("bf21_DetaDphi_shft"));
+
 
    if (ac.fillY)
    {
@@ -117,6 +128,14 @@ ParticlePairDerivedHistos::ParticlePairDerivedHistos(const TString & name,
      h_G2_DyDphi_shft     = loadH2(inputFile, bn+TString("G2_DyDphi_shft"));
      h_P2_yY              = loadH2(inputFile, bn+TString("P2_yY"));
 
+     h_bf12_phiYPhiY      = loadH2(inputFile, bn+TString("bf12_phiYPhiY"));
+     h_bf12_yY            = loadH2(inputFile, bn+TString("bf12_yY"));
+     h_bf12_DyDphi        = loadH2(inputFile, bn+TString("bf12_DyDphi"));
+     h_bf12_DyDphi_shft   = loadH2(inputFile, bn+TString("bf12_DyDphi_shft"));
+     h_bf21_phiYPhiY      = loadH2(inputFile, bn+TString("bf21_phiYPhiY"));
+     h_bf21_yY            = loadH2(inputFile, bn+TString("bf21_yY"));
+     h_bf21_DyDphi        = loadH2(inputFile, bn+TString("bf21_DyDphi"));
+     h_bf21_DyDphi_shft   = loadH2(inputFile, bn+TString("bf21_DyDphi_shft"));
    }
    if (reportDebug()) cout << "ParticlePairDerivedHistos::loadHistograms() Completed." << endl;
  }
@@ -193,6 +212,18 @@ ParticlePairDerivedHistos::ParticlePairDerivedHistos(const TString & name,
    h_G2_DetaDphi          = createHistogram(bn+TString("G2_DetaDphi"),         ac.nBins_Deta,  ac.min_Deta,  ac.max_Deta,  ac.nBins_Dphi,  ac.min_Dphi,      ac.max_Dphi,      "#Delta#eta","#Delta#varphi",   "G_{2}", 0,1,0,0);
    h_G2_DetaDphi_shft     = createHistogram(bn+TString("G2_DetaDphi_shft"),    ac.nBins_Deta,  ac.min_Deta,  ac.max_Deta,  ac.nBins_Dphi,  ac.min_Dphi_shft, ac.max_Dphi_shft, "#Delta#eta", "#Delta#varphi",  "G_{2}", 0,1,0,0);
 
+   h_bf12_phiEtaPhiEta    = createHistogram(bn+TString("bf12_phiEtaPhiEta"),   ac.nBins_phiEta, static_cast<double>(0.),double(ac.nBins_phiEta), ac.nBins_phiEta, 0.,double(ac.nBins_phiEta),       "#eta x #varphi", "#eta x #varphi","n_{2}^{12}/n_{1}^{2}", false, true, false, false);
+   h_bf12_etaEta          = createHistogram(bn+TString("bf12_etaEta"),         ac.nBins_eta,   ac.min_eta,   ac.max_eta,   ac.nBins_eta,   ac.min_eta,  ac.max_eta,            "#eta_{1}", "#eta_{2}",         "n_{2}^{12}/n_{1}^{2}", false, true, false, false);
+   h_bf12_phiPhi          = createHistogram(bn+TString("bf12_phiPhi"),         ac.nBins_phi,   ac.min_phi,   ac.max_phi,   ac.nBins_phi,   ac.min_phi,  ac.max_phi,            "#varphi_{1}", "#varphi_{2}",   "n_{2}^{12}/n_{1}^{2}", false, true, false, false);
+   h_bf12_DetaDphi        = createHistogram(bn+TString("bf12_DetaDphi"),       ac.nBins_Deta,  ac.min_Deta,  ac.max_Deta,  ac.nBins_Dphi,  ac.min_Dphi,      ac.max_Dphi,      "#Delta#eta","#Delta#varphi",   "n_{2}^{12}/n_{1}^{2}", false, true, false, false);
+   h_bf12_DetaDphi_shft   = createHistogram(bn+TString("bf12_DetaDphi_shft"),  ac.nBins_Deta,  ac.min_Deta,  ac.max_Deta,  ac.nBins_Dphi,  ac.min_Dphi_shft, ac.max_Dphi_shft, "#Delta#eta", "#Delta#varphi",  "n_{2}^{12}/n_{1}^{2}", false, true, false, false);
+   h_bf21_phiEtaPhiEta    = createHistogram(bn+TString("bf21_phiEtaPhiEta"),   ac.nBins_phiEta, static_cast<double>(0.),double(ac.nBins_phiEta), ac.nBins_phiEta, 0.,double(ac.nBins_phiEta),       "#eta x #varphi", "#eta x #varphi","n_{2}^{21}/n_{1}^{1}", false, true, false, false);
+   h_bf21_etaEta          = createHistogram(bn+TString("bf21_etaEta"),         ac.nBins_eta,   ac.min_eta,   ac.max_eta,   ac.nBins_eta,   ac.min_eta,  ac.max_eta,            "#eta_{1}", "#eta_{2}",         "n_{2}^{21}/n_{1}^{1}", false, true, false, false);
+   h_bf21_phiPhi          = createHistogram(bn+TString("bf21_phiPhi"),         ac.nBins_phi,   ac.min_phi,   ac.max_phi,   ac.nBins_phi,   ac.min_phi,  ac.max_phi,            "#varphi_{1}", "#varphi_{2}",   "n_{2}^{21}/n_{1}^{1}", false, true, false, false);
+   h_bf21_DetaDphi        = createHistogram(bn+TString("bf21_DetaDphi"),       ac.nBins_Deta,  ac.min_Deta,  ac.max_Deta,  ac.nBins_Dphi,  ac.min_Dphi,      ac.max_Dphi,      "#Delta#eta","#Delta#varphi",   "n_{2}^{21}/n_{1}^{1}", false, true, false, false);
+   h_bf21_DetaDphi_shft   = createHistogram(bn+TString("bf21_DetaDphi_shft"),  ac.nBins_Deta,  ac.min_Deta,  ac.max_Deta,  ac.nBins_Dphi,  ac.min_Dphi_shft, ac.max_Dphi_shft, "#Delta#eta", "#Delta#varphi",  "n_{2}^{21}/n_{1}^{1}", false, true, false, false);
+
+
    if (ac.fillY)
    {
      h_n1n1_phiYPhiY     = createHistogram(bn+TString("n1n1_phiYPhiY"),     ac.nBins_phiY, static_cast<double>(0.),double(ac.nBins_phiY), ac.nBins_phiY, 0.,double(ac.nBins_phiY),        "y_{1} x #varphi_{1}", "y_{2} x #varphi_{2}", "<n_{1}><n_{1}>", 0,1,0,0);
@@ -228,6 +259,16 @@ ParticlePairDerivedHistos::ParticlePairDerivedHistos(const TString & name,
      h_G2_yY             = createHistogram(bn+TString("G2_yY"),             ac.nBins_y,   ac.min_y,   ac.max_y,   ac.nBins_y,   ac.min_y,  ac.max_y,                  "y_{1}",    "y_{2}", "G_{2}", 0,1,0,0);
      h_G2_DyDphi         = createHistogram(bn+TString("G2_DyDphi"),         ac.nBins_Dy,  ac.min_Dy,  ac.max_Dy,  ac.nBins_Dphi,  ac.min_Dphi,      ac.max_Dphi,      "#Delta y", "#Delta#varphi", "G_{2}", 0,1,0,0);
      h_G2_DyDphi_shft    = createHistogram(bn+TString("G2_DyDphi_shft"),    ac.nBins_Dy,  ac.min_Dy,  ac.max_Dy,  ac.nBins_Dphi,  ac.min_Dphi_shft, ac.max_Dphi_shft, "#Delta y", "#Delta#varphi", "G_{2}", 0,1,0,0);
+
+
+     h_bf12_phiYPhiY     = createHistogram(bn+TString("bf12_phiYPhiY"),     ac.nBins_phiY, static_cast<double>(0.),double(ac.nBins_phiY), ac.nBins_phiY, 0.,double(ac.nBins_phiY),         "y_{1} x #varphi_{1}", "y_{2} x #varphi_{2}", "n_{2}^{12}/n_{1}^{2}", false, true, false, false);
+     h_bf12_yY           = createHistogram(bn+TString("bf12_yY"),           ac.nBins_y,   ac.min_y,   ac.max_y,   ac.nBins_y,   ac.min_y,  ac.max_y,                  "y_{1}",    "y_{2}", "n_{2}^{12}/n_{1}^{2}", false, true, false, false);
+     h_bf12_DyDphi       = createHistogram(bn+TString("bf12_DyDphi"),       ac.nBins_Dy,  ac.min_Dy,  ac.max_Dy,  ac.nBins_Dphi,  ac.min_Dphi,      ac.max_Dphi,      "#Delta y", "#Delta#varphi", "n_{2}^{12}/n_{1}^{2}", false, true, false, false);
+     h_bf12_DyDphi_shft  = createHistogram(bn+TString("bf12_DyDphi_shft"),  ac.nBins_Dy,  ac.min_Dy,  ac.max_Dy,  ac.nBins_Dphi,  ac.min_Dphi_shft, ac.max_Dphi_shft, "#Delta y", "#Delta#varphi", "n_{2}^{12}/n_{1}^{2}", false, true, false, false);
+     h_bf21_phiYPhiY     = createHistogram(bn+TString("bf21_phiYPhiY"),     ac.nBins_phiY, static_cast<double>(0.),double(ac.nBins_phiY), ac.nBins_phiY, 0.,double(ac.nBins_phiY),         "y_{1} x #varphi_{1}", "y_{2} x #varphi_{2}", "n_{2}^{21}/n_{1}^{1}", false, true, false, false);
+     h_bf21_yY           = createHistogram(bn+TString("bf21_yY"),           ac.nBins_y,   ac.min_y,   ac.max_y,   ac.nBins_y,   ac.min_y,  ac.max_y,                  "y_{1}",    "y_{2}", "n_{2}^{21}/n_{1}^{1}", false, true, false, false);
+     h_bf21_DyDphi       = createHistogram(bn+TString("bf21_DyDphi"),       ac.nBins_Dy,  ac.min_Dy,  ac.max_Dy,  ac.nBins_Dphi,  ac.min_Dphi,      ac.max_Dphi,      "#Delta y", "#Delta#varphi", "n_{2}^{21}/n_{1}^{1}", false, true, false, false);
+     h_bf21_DyDphi_shft  = createHistogram(bn+TString("bf21_DyDphi_shft"),  ac.nBins_Dy,  ac.min_Dy,  ac.max_Dy,  ac.nBins_Dphi,  ac.min_Dphi_shft, ac.max_Dphi_shft, "#Delta y", "#Delta#varphi", "n_{2}^{21}/n_{1}^{1}", false, true, false, false);
 
      h_n1n1_Q3D          = createHistogram(bn+TString("n1n1_Q3D"),
                                             ac.nBins_DeltaPlong, ac.min_DeltaPlong, ac.max_DeltaPlong,
@@ -553,7 +594,14 @@ ParticlePairDerivedHistos::ParticlePairDerivedHistos(const TString & name,
     symmetrizeXX( h_R2_phiPhi,   ijNormalization);
     */
 
-
+   /* balance functions components not R2 based */
+   calculateBf( pairHistos->h_n2_phiEtaPhiEta,part1Histos->h_n1_phiEta,part2Histos->h_n1_phiEta,h_bf12_phiEtaPhiEta,h_bf21_phiEtaPhiEta );
+   calculateBf( pairHistos->h_n2_etaEta,part1Histos->h_n1_phiEta,part2Histos->h_n1_phiEta,h_bf12_etaEta,h_bf21_etaEta );
+   calculateBf( pairHistos->h_n2_phiPhi,part1Histos->h_n1_phiEta,part2Histos->h_n1_phiEta,h_bf12_phiPhi,h_bf21_phiPhi );
+   reduce_n2xEtaPhi_n2DetaDphi( h_bf12_phiEtaPhiEta, h_bf12_DetaDphi, ac.nBins_eta, ac.nBins_phi);
+   reduce_n2xEtaPhi_n2DetaDphi( h_bf21_phiEtaPhiEta, h_bf21_DetaDphi, ac.nBins_eta, ac.nBins_phi);
+   shiftY(*h_bf12_DetaDphi, *h_bf12_DetaDphi_shft, ac.nBins_Dphi_shft);
+   shiftY(*h_bf21_DetaDphi, *h_bf21_DetaDphi_shft, ac.nBins_Dphi_shft);
 
    if (ac.fillY)
    {
@@ -607,6 +655,14 @@ ParticlePairDerivedHistos::ParticlePairDerivedHistos(const TString & name,
      shiftY(*h_DptDpt_DyDphi,  *h_DptDpt_DyDphi_shft,  ac.nBins_Dphi_shft);
      shiftY(*h_P2_DyDphi,      *h_P2_DyDphi_shft,      ac.nBins_Dphi_shft);
      shiftY(*h_G2_DyDphi,      *h_G2_DyDphi_shft,      ac.nBins_Dphi_shft);
+
+    /* balance functions components not R2 based */
+    calculateBf( pairHistos->h_n2_phiYPhiY,part1Histos->h_n1_phiY,part2Histos->h_n1_phiY,h_bf12_phiYPhiY,h_bf21_phiYPhiY );
+    calculateBf( pairHistos->h_n2_yY,part1Histos->h_n1_phiY,part2Histos->h_n1_phiY,h_bf12_yY,h_bf21_yY );
+    reduce_n2xEtaPhi_n2DetaDphi( h_bf12_phiYPhiY, h_bf12_DyDphi, ac.nBins_y, ac.nBins_phi);
+    reduce_n2xEtaPhi_n2DetaDphi( h_bf21_phiYPhiY, h_bf21_DyDphi, ac.nBins_y, ac.nBins_phi);
+    shiftY(*h_bf12_DyDphi, *h_bf12_DyDphi_shft, ac.nBins_Dphi_shft);
+    shiftY(*h_bf21_DyDphi, *h_bf21_DyDphi_shft, ac.nBins_Dphi_shft);
    }
 
    if (reportDebug()) cout << "ParticlePairDerivedHistos::calculateDerivedHistograms() completed."<< endl;

--- a/Base/ParticlePairDerivedHistos.hpp
+++ b/Base/ParticlePairDerivedHistos.hpp
@@ -62,6 +62,26 @@ public:
   TH2* h_G2_etaEta;
   TH2* h_G2_phiPhi;
 
+  /* the balance functions components not R2 based */
+  TH2* h_bf12_phiEtaPhiEta;
+  TH2* h_bf12_etaEta;
+  TH2* h_bf12_phiPhi;
+  TH2* h_bf12_phiYPhiY;
+  TH2* h_bf12_yY;
+  TH2* h_bf12_DetaDphi;
+  TH2* h_bf12_DyDphi;
+  TH2* h_bf12_DetaDphi_shft;
+  TH2* h_bf12_DyDphi_shft;
+  TH2* h_bf21_phiEtaPhiEta;
+  TH2* h_bf21_etaEta;
+  TH2* h_bf21_phiPhi;
+  TH2* h_bf21_phiYPhiY;
+  TH2* h_bf21_yY;
+  TH2* h_bf21_DetaDphi;
+  TH2* h_bf21_DyDphi;
+  TH2* h_bf21_DetaDphi_shft;
+  TH2* h_bf21_DyDphi_shft;
+
   TH2* h_n1n1_DetaDphi;
   TH2* h_pt1pt1_DetaDphi;
   TH2* h_n2_DetaDphi;
@@ -140,7 +160,7 @@ public:
   
   bool ijNormalization;
 
-    ClassDef(ParticlePairDerivedHistos,0)
+    ClassDef(ParticlePairDerivedHistos,1)
 
 };
 


### PR DESCRIPTION
I implemented the BF extraction considering the BF expression and not its relation with R2
`BF = n2_ab(DEta,DPhi)/n1_b + n2_ba(DEta,DPhi)/n1_a - n2_aa(DEta,DPhi)/n1_a - n2_bb(DEta,DPhi)/n1_b`